### PR TITLE
Can open app when bubble is touched

### DIFF
--- a/library/android/src/main/java/com/reactlibrary/RNFloatingBubbleModule.java
+++ b/library/android/src/main/java/com/reactlibrary/RNFloatingBubbleModule.java
@@ -39,6 +39,14 @@ public class RNFloatingBubbleModule extends ReactContextBaseJavaModule {
     // }
   }
 
+  @ReactMethod
+  public void reopenApp(){
+    Intent launchIntent = reactContext.getPackageManager().getLaunchIntentForPackage(reactContext.getPackageName());
+    if (launchIntent != null) {
+      reactContext.startActivity(launchIntent);
+    }
+  }
+
   @Override
   public String getName() {
     return "RNFloatingBubble";

--- a/library/index.js
+++ b/library/index.js
@@ -3,10 +3,11 @@ import { NativeModules } from 'react-native';
 
 const { RNFloatingBubble } = NativeModules;
 
+export const reopenApp = () => RNFloatingBubble.reopenApp();
 export const showFloatingBubble = (x = 50, y = 100) => RNFloatingBubble.showFloatingBubble(x, y);
 export const hideFloatingBubble = () => RNFloatingBubble.hideFloatingBubble();
 export const checkPermission = () => RNFloatingBubble.checkPermission();
 export const requestPermission = () => RNFloatingBubble.requestPermission();
 export const initialize = () => RNFloatingBubble.initialize();
 
-export default { showFloatingBubble, hideFloatingBubble, requestPermission, checkPermission, initialize };
+export default { showFloatingBubble, hideFloatingBubble, requestPermission, checkPermission, initialize, reopenApp };


### PR DESCRIPTION
To work you have to import one more method from the library called `reopenApp`:

```javascript
import {
  initialize, requestPermission, showFloatingBubble, reopenApp
} from 'react-native-floating-bubble'
```

To use this on the application, add this method on listener:

```javascript
const subscriptionPress = DeviceEventEmitter.addListener('floating-bubble-press', () => {
      reopenApp()
    })
```

