### PR TITLE
Update RNFloatingBubble.podspec

### DIFF
--- a/library/ios/RNFloatingBubble.podspec
+++ b/library/ios/RNFloatingBubble.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNFloatingBubble
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/author/RNFloatingBubble.git"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
iOS solution to the problem: 
The `RNFloatingBubble` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.